### PR TITLE
Fix AI gateway Dockerfile

### DIFF
--- a/services/ai_gateway/Dockerfile
+++ b/services/ai_gateway/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim
 WORKDIR /app
-RUN pip install fastapi uvicorn
-COPY main.py .
+RUN pip install fastapi uvicorn httpx sqlmodel redis
+COPY . .
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- copy the whole ai_gateway directory into the container
- install all Python dependencies needed by the service

## Testing
- `DATABASE_URL=sqlite:///$(mktemp -u).db pytest -q`
- `docker-compose build ai-gateway` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847d0a99d008332bcb649d158cbee0b