### PR TITLE
Add automation service with AI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This repository contains a minimal skeleton for an AI-powered automation platfor
 - **Auth Service** (`services/auth_svc`): Handles authentication and tenant user management.
 - **AI Gateway** (`services/ai_gateway`): Forwards completion requests to LLM providers.
 - **Ingestion Worker** (`services/ingestion_worker`): Example CLI that ingests data.
+- **Automation Service** (`services/automation_svc`): Simple orchestration layer that
+  calls the AI gateway and stores task results.
 - **UI** (`ui`): Placeholder front-end.
 
 ## Getting Started

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,10 @@ services:
     build: ./services/ai_gateway
     ports:
       - "8002:8000"
+  automation-svc:
+    build: ./services/automation_svc
+    ports:
+      - "8003:8000"
   pg-db:
     image: postgres:15
     environment:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ sqlmodel
 pyjwt
 passlib[bcrypt]
 httpx<0.28
+openai

--- a/services/ai_gateway/main.py
+++ b/services/ai_gateway/main.py
@@ -1,8 +1,30 @@
+import os
+
+import httpx
 from fastapi import FastAPI
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 
 app = FastAPI(title="AI Gateway")
 
 
 @app.post("/ai/completions")
 async def completions(model: str, prompt: str, tenant: str):
-    return {"model": model, "prompt": prompt, "tenant": tenant, "result": "..."}
+    if OPENAI_API_KEY:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                "https://api.openai.com/v1/chat/completions",
+                headers={"Authorization": f"Bearer {OPENAI_API_KEY}"},
+                json={
+                    "model": model,
+                    "messages": [{"role": "user", "content": prompt}],
+                },
+                timeout=30,
+            )
+        response.raise_for_status()
+        data = response.json()
+        result = data["choices"][0]["message"]["content"]
+    else:
+        # Fallback behavior when no API key provided
+        result = prompt[::-1]
+    return {"model": model, "prompt": prompt, "tenant": tenant, "result": result}

--- a/services/api_gateway/main.py
+++ b/services/api_gateway/main.py
@@ -1,4 +1,9 @@
+import os
+
+import httpx
 from fastapi import FastAPI
+
+AUTOMATION_URL = os.getenv("AUTOMATION_URL", "http://automation-svc:8000")
 
 app = FastAPI(title="API Gateway")
 
@@ -6,3 +11,15 @@ app = FastAPI(title="API Gateway")
 @app.get("/")
 async def root():
     return {"message": "API Gateway running"}
+
+
+@app.post("/run")
+async def run(model: str, prompt: str, tenant: str):
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{AUTOMATION_URL}/tasks",
+            params={"model": model, "prompt": prompt, "tenant": tenant},
+            timeout=60,
+        )
+    resp.raise_for_status()
+    return resp.json()

--- a/services/automation_svc/Dockerfile
+++ b/services/automation_svc/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.12-slim
+WORKDIR /app
+RUN pip install fastapi uvicorn httpx
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/automation_svc/main.py
+++ b/services/automation_svc/main.py
@@ -1,0 +1,33 @@
+import os
+from uuid import uuid4
+
+import httpx
+from fastapi import FastAPI, HTTPException
+
+AI_GATEWAY_URL = os.getenv("AI_GATEWAY_URL", "http://ai-gateway:8000/ai/completions")
+
+app = FastAPI(title="Automation Service")
+
+# In-memory task store for demo purposes
+TASKS: dict[str, dict] = {}
+
+
+@app.post("/tasks")
+async def create_task(model: str, prompt: str, tenant: str):
+    task_id = str(uuid4())
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            AI_GATEWAY_URL,
+            params={"model": model, "prompt": prompt, "tenant": tenant},
+            timeout=60,
+        )
+    resp.raise_for_status()
+    TASKS[task_id] = resp.json()
+    return {"task_id": task_id}
+
+
+@app.get("/tasks/{task_id}")
+async def get_task(task_id: str):
+    if task_id not in TASKS:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return TASKS[task_id]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -2,14 +2,19 @@ import sys
 from pathlib import Path
 
 from fastapi.testclient import TestClient
+from sqlmodel import create_engine
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from services.auth_svc.main import app
+from services.auth_svc import database
 
 
 def test_signup_and_list_users(tmp_path, monkeypatch):
-    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path/'test.db'}")
+    db_url = f"sqlite:///{tmp_path/'test.db'}"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    database.engine = create_engine(db_url, connect_args={"check_same_thread": False})
+    database.init_db()
     with TestClient(app) as client:
         response = client.post(
             "/auth/signup",

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -1,0 +1,39 @@
+import httpx
+from fastapi.testclient import TestClient
+from services.automation_svc.main import app, TASKS
+
+
+def test_create_and_get_task(monkeypatch):
+    async def fake_post(self, url, params=None, timeout=None):
+        class FakeResponse:
+            def __init__(self):
+                self.status_code = 200
+                self._json = {
+                    "model": params["model"],
+                    "prompt": params["prompt"],
+                    "tenant": params["tenant"],
+                    "result": "ok",
+                }
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return self._json
+
+        return FakeResponse()
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post, raising=False)
+
+    TASKS.clear()
+    with TestClient(app) as client:
+        resp = client.post(
+            "/tasks",
+            params={"model": "gpt", "prompt": "hi", "tenant": "1"},
+        )
+        assert resp.status_code == 200
+        task_id = resp.json()["task_id"]
+
+        resp = client.get(f"/tasks/{task_id}")
+        assert resp.status_code == 200
+        assert resp.json()["result"] == "ok"

--- a/ui/index.html
+++ b/ui/index.html
@@ -5,6 +5,26 @@
 </head>
 <body>
 <h1>AI Copilot</h1>
-<p>Placeholder UI</p>
+<form id="task-form">
+  <label>Model: <input id="model" value="gpt-3.5-turbo" /></label><br />
+  <label>Prompt: <input id="prompt" value="Hello" /></label><br />
+  <label>Tenant: <input id="tenant" value="1" /></label><br />
+  <button type="submit">Run</button>
+</form>
+<pre id="output"></pre>
+
+<script>
+document.getElementById('task-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const res = await fetch('/run?model=' +
+    encodeURIComponent(document.getElementById('model').value) +
+    '&prompt=' + encodeURIComponent(document.getElementById('prompt').value) +
+    '&tenant=' + encodeURIComponent(document.getElementById('tenant').value), {
+    method: 'POST'
+  });
+  const data = await res.json();
+  document.getElementById('output').textContent = JSON.stringify(data, null, 2);
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add simple automation service that forwards tasks to AI gateway
- expand API gateway to proxy to automation service
- enhance AI gateway with optional OpenAI integration
- update README and docker-compose to include the new service
- create basic UI form and tests for automation
- fix auth test DB initialization

## Testing
- `black services tests -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d1ee293c83329ba70bb5e60e2303