### PR TITLE
Add encryption microservice

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This repository contains a minimal skeleton for an AI-powered automation platfor
 - **Ingestion Worker** (`services/ingestion_worker`): Example CLI that ingests data.
 - **Automation Service** (`services/automation_svc`): Simple orchestration layer that
   calls the AI gateway and stores task results.
+- **Encryption Service** (`services/encryption_svc`): Provides basic AES
+  encryption and decryption endpoints.
 - **UI** (`ui`): Placeholder front-end.
 
 ## Getting Started

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,10 @@ services:
     build: ./services/automation_svc
     ports:
       - "8003:8000"
+  encryption-svc:
+    build: ./services/encryption_svc
+    ports:
+      - "8004:8000"
   pg-db:
     image: postgres:15
     environment:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyjwt
 passlib[bcrypt]
 httpx<0.28
 openai
+cryptography

--- a/services/encryption_svc/Dockerfile
+++ b/services/encryption_svc/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY ../../requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/encryption_svc/main.py
+++ b/services/encryption_svc/main.py
@@ -1,0 +1,42 @@
+import os
+import base64
+from fastapi import FastAPI, HTTPException
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives import padding
+from cryptography.hazmat.backends import default_backend
+
+
+SECRET_KEY = os.getenv("ENCRYPTION_KEY", "A" * 32).encode()
+IV = b"0123456789abcdef"
+
+app = FastAPI(title="Encryption Service")
+
+
+def _get_cipher() -> Cipher:
+    return Cipher(
+        algorithms.AES(SECRET_KEY), modes.CBC(IV), backend=default_backend()
+    )
+
+
+@app.post("/encrypt")
+def encrypt_data(data: str):
+    cipher = _get_cipher()
+    padder = padding.PKCS7(128).padder()
+    padded_data = padder.update(data.encode()) + padder.finalize()
+    encryptor = cipher.encryptor()
+    ciphertext = encryptor.update(padded_data) + encryptor.finalize()
+    return {"ciphertext": base64.b64encode(ciphertext).decode()}
+
+
+@app.post("/decrypt")
+def decrypt_data(ciphertext: str):
+    cipher = _get_cipher()
+    decryptor = cipher.decryptor()
+    try:
+        decoded = base64.b64decode(ciphertext.encode())
+        decrypted = decryptor.update(decoded) + decryptor.finalize()
+        unpadder = padding.PKCS7(128).unpadder()
+        data = unpadder.update(decrypted) + unpadder.finalize()
+    except Exception as e:  # pragma: no cover - defensive programming
+        raise HTTPException(status_code=400, detail="Invalid ciphertext") from e
+    return {"data": data.decode()}

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -1,0 +1,13 @@
+from fastapi.testclient import TestClient
+from services.encryption_svc.main import app
+
+
+def test_encrypt_and_decrypt():
+    with TestClient(app) as client:
+        resp = client.post("/encrypt", params={"data": "secret"})
+        assert resp.status_code == 200
+        ciphertext = resp.json()["ciphertext"]
+
+        resp = client.post("/decrypt", params={"ciphertext": ciphertext})
+        assert resp.status_code == 200
+        assert resp.json()["data"] == "secret"


### PR DESCRIPTION
## Summary
- add AES-based encryption service with `/encrypt` and `/decrypt` endpoints
- include service in docker-compose config
- install cryptography library
- test encryption service
- document new service in README

## Testing
- `pytest -q`
- `make precommit`

------
https://chatgpt.com/codex/tasks/task_e_68818eb8171483329dc7bc9edafaf926